### PR TITLE
Multicast and bringup fixes.

### DIFF
--- a/jetson/bringup.sh
+++ b/jetson/bringup.sh
@@ -9,6 +9,15 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 export SERVICE_DIR=$( cd "$( dirname "${SOURCE}" )" >/dev/null 2>&1 && pwd )
 
+# add some routes for wlan0, lo
+route add -net 224.0.0.0 netmask 240.0.0.0 dev lo
+route add -net 224.0.0.0 netmask 240.0.0.0 dev wlan0
+
+
+# enable multicast on loopback, cause we may not have a wireless or wired link.
+ifconfig lo multicast
+ifconfig wlan0 multicast
+
 # Power cycle the usb bus, due to an issue with the t265 camera
 # bootloader having a race condition if power is supplied before the
 # usb is ready.  uhubctl can power cycle the nano usb bus power in a
@@ -23,6 +32,8 @@ export SERVICE_DIR=$( cd "$( dirname "${SOURCE}" )" >/dev/null 2>&1 && pwd )
 sleep 1
 
 $SERVICE_DIR/bringup_can.sh
+touch /tmp/tractor-ready.touch
+
 while true
 do
     ip -details -statistics link show can0

--- a/jetson/install.sh
+++ b/jetson/install.sh
@@ -14,10 +14,16 @@ prefix=/opt/farm_ng make -C $SERVICE_DIR/uhubctl
 prefix=/opt/farm_ng make -C $SERVICE_DIR/uhubctl install
 cp $SERVICE_DIR/*.sh /opt/farm_ng/systemd
 cp $SERVICE_DIR/*.service /etc/systemd/system/
+cp $SERVICE_DIR/*.path /etc/systemd/system/
 
 systemctl daemon-reload
 
 # start on boot always...
 systemctl enable tractor-bringup.service
+systemctl enable tractor-ready.path
 systemctl enable tractor-steering.service
 systemctl enable tractor.service
+
+systemctl start tractor-ready.path
+systemctl start tractor-steering.service
+systemctl start tractor-bringup.service

--- a/jetson/tractor-bringup.service
+++ b/jetson/tractor-bringup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description="Tractor canbus service"
-After=network.target
+BindsTo=sys-subsystem-net-devices-wlan0.device sys-subsystem-net-devices-usb0.device
+After=sys-subsystem-net-devices-wlan0.device sys-subsystem-net-devices-usb0.device
 
 [Service]
 ExecStart=/opt/farm_ng/systemd/bringup.sh

--- a/jetson/tractor-ready.path
+++ b/jetson/tractor-ready.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor /bin/tractor-ready.touch and start tractor
+
+[Path]
+PathExists=/tmp/tractor-ready.touch
+Unit=tractor.service
+
+[Install]
+WantedBy=multi-user.target

--- a/jetson/tractor-steering.service
+++ b/jetson/tractor-steering.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=tractor steering service
 Requires=bluetooth.service
-After=bluetooth.service
+After=bluetooth.service tractor-bringup.service
 Wants=tractor-bringup
 
 [Service]

--- a/jetson/tractor.service
+++ b/jetson/tractor.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Tractor service.
-After=network.target
-Wants=tractor-bringup
+ConditionPathExists=/tmp/tractor-ready.touch
 
 [Service]
 ExecStart=/home/farmer/tractor/jetson/tractor.sh

--- a/jetson/tractor.sh
+++ b/jetson/tractor.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -ex
-sleep 5 # TODO(ethanrublee) hack remove this!
 . setup.bash
 python -m farm_ng.tractor

--- a/jetson/tractor.sh
+++ b/jetson/tractor.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -ex
+sleep 5 # TODO(ethanrublee) hack remove this!
 . setup.bash
 python -m farm_ng.tractor


### PR DESCRIPTION
- Use a systemd.path unit to detect when the canbus and usb are ready
from tractor-bringup.service
- Enable multicast on loopback, in case the robot is not connected to
wifi.