### PR TITLE
Tractor config proto 68

### DIFF
--- a/protos/farm_ng_proto/tractor/v1/geometry.proto
+++ b/protos/farm_ng_proto/tractor/v1/geometry.proto
@@ -45,10 +45,6 @@ message NamedSE3Pose {
   string frame_b = 3;
 }
 
-message PoseTree {
-  repeated NamedSE3Pose poses = 1;
-}
-
 message Matrix {
   uint32 rows = 1;
   uint32 cols = 2;

--- a/protos/farm_ng_proto/tractor/v1/geometry.proto
+++ b/protos/farm_ng_proto/tractor/v1/geometry.proto
@@ -45,6 +45,10 @@ message NamedSE3Pose {
   string frame_b = 3;
 }
 
+message PoseTree {
+  repeated NamedSE3Pose poses = 1;
+}
+
 message Matrix {
   uint32 rows = 1;
   uint32 cols = 2;

--- a/protos/farm_ng_proto/tractor/v1/tractor.proto
+++ b/protos/farm_ng_proto/tractor/v1/tractor.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 import "google/protobuf/wrappers.proto";
-import "farm_ng_proto/tractor/v1/geometry.proto";
 
 package farm_ng_proto.tractor.v1;
 option go_package = "github.com/farm_ng/genproto";
@@ -23,6 +22,4 @@ message TractorConfig {
   // Hub motor polls
   google.protobuf.Int32Value hub_motor_poll_pairs = 4;
 
-  // Extrinsic relationship of sensors and motors.
-  PoseTree extrinsics = 5;
 }

--- a/protos/farm_ng_proto/tractor/v1/tractor.proto
+++ b/protos/farm_ng_proto/tractor/v1/tractor.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 
+import "google/protobuf/wrappers.proto";
+import "farm_ng_proto/tractor/v1/geometry.proto";
+
 package farm_ng_proto.tractor.v1;
 option go_package = "github.com/farm_ng/genproto";
 
@@ -8,4 +11,18 @@ message TractorState {
   // program starts, which is usually on system boot; i.e. it will reset if the
   // program or computer is restarted.
   double abs_distance_traveled = 1;
+}
+
+message TractorConfig {
+  // distance between the wheels, in meters
+  google.protobuf.DoubleValue wheel_baseline = 1;
+  // Radius of wheel, in meters.
+  google.protobuf.DoubleValue wheel_radius = 2;
+  // Hub motor gear ratio
+  google.protobuf.DoubleValue hub_motor_gear_ratio = 3;
+  // Hub motor polls
+  google.protobuf.Int32Value hub_motor_poll_pairs = 4;
+
+  // Extrinsic relationship of sensors and motors.
+  PoseTree extrinsics = 5;
 }

--- a/python/farm_ng/config.py
+++ b/python/farm_ng/config.py
@@ -37,6 +37,9 @@ def main():
     parser_gen.add_argument('--hub_motor_poll_pairs', help='Number of pools in drive motor', default=cfg.hub_motor_poll_pairs.value, type=int)
     parser_gen.set_defaults(func=main_gen)
     args = parser.parse_args()
+    if not hasattr(args, 'func'):
+        parser.print_help()
+        return
     args.func(args)
 
 

--- a/python/farm_ng/config.py
+++ b/python/farm_ng/config.py
@@ -1,0 +1,44 @@
+import argparse
+
+from farm_ng_proto.tractor.v1.tractor_pb2 import TractorConfig
+from google.protobuf.json_format import MessageToJson
+
+
+def _in2m(inches: float) -> float:
+    return 0.0254*inches
+
+
+def default_config() -> TractorConfig:
+    config = TractorConfig()
+    config.wheel_baseline.value = _in2m(42.0)
+    config.wheel_radius.value = _in2m(17/2.0)
+    config.hub_motor_gear_ratio.value = 29.9
+    config.hub_motor_poll_pairs.value = 8
+    return config
+
+
+def main_gen(args):
+    config = default_config()
+    config.wheel_baseline.value = args.wheel_baseline
+    config.wheel_radius.value = args.wheel_radius
+    config.hub_motor_gear_ratio.value = args.hub_motor_gear_ratio
+    config.hub_motor_poll_pairs.value = args.hub_motor_poll_pairs
+    print(MessageToJson(config))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    parser_gen = subparsers.add_parser('gen')
+    cfg = default_config()
+    parser_gen.add_argument('--wheel_baseline', help='Distance between wheels in meters', default=cfg.wheel_baseline.value, type=float)
+    parser_gen.add_argument('--wheel_radius', help='Radius of drive wheels in meters', default=cfg.wheel_radius.value, type=float)
+    parser_gen.add_argument('--hub_motor_gear_ratio', help='Gear ratio of drive motor', default=cfg.hub_motor_gear_ratio.value, type=float)
+    parser_gen.add_argument('--hub_motor_poll_pairs', help='Number of pools in drive motor', default=cfg.hub_motor_poll_pairs.value, type=int)
+    parser_gen.set_defaults(func=main_gen)
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/farm_ng/kinematics.py
+++ b/python/farm_ng/kinematics.py
@@ -1,12 +1,13 @@
 from typing import Tuple
 
+from farm_ng_proto.tractor.v1.tractor_pb2 import TractorConfig
 from liegroups import SE3
 
 
 class TractorKinematics:
-    def __init__(self):
-        self.wheel_radius = 1.0  # 0.0254*17/2.0
-        self.wheel_base_line = 0.0254*46
+    def __init__(self, tractor_config: TractorConfig):
+        self.wheel_radius = tractor_config.wheel_radius.value
+        self.wheel_base_line = tractor_config.wheel_baseline.value
 
     def wheel_velocity_to_unicycle(self, v_left: float, v_right: float) -> Tuple[float, float]:
         v = (self.wheel_radius/2.0)*(v_left+v_right)

--- a/python/farm_ng/motor.py
+++ b/python/farm_ng/motor.py
@@ -145,9 +145,9 @@ class HubMotor:
         self.can_socket.add_reader(self._handle_can_message)
         self._last_tachometer = 0
         self._last_tachometer_stamp = None
-        self._delta_meters = 0.0
+        self._delta_rads = 0.0
         self._delta_time_seconds = 0.0
-        self._avg_velocity = 0.0
+        self._avg_velocity_rads = 0.0
 
     def _handle_can_message(self, cob_id, data, stamp):
         can_node_id = (cob_id & 0xff)
@@ -176,9 +176,9 @@ class HubMotor:
                 # meters=revs * 2*math.pi*radius
                 # miles=meters/1609
                 # with radius of 0.215 meters, we get 1261 miles
-                self._delta_meters = self._er_to_meters(self._latest_state.tachometer.value - self._last_tachometer)
+                self._delta_rads = self._er_to_rads(self._latest_state.tachometer.value - self._last_tachometer)
                 self._delta_time_seconds = (self._latest_stamp.ToMicroseconds() - self._last_tachometer_stamp.ToMicroseconds())*1e-6
-                self._avg_velocity = self._delta_meters / self._delta_time_seconds
+                self._avg_velocity_rads = self._delta_rads / self._delta_time_seconds
 
             else:
                 self._last_tachometer_stamp = Timestamp()
@@ -198,17 +198,19 @@ class HubMotor:
         eff_flag = 0x80000000
         self.can_socket.send(cob_id, data, flags=eff_flag)
 
-    def _er_to_meters(self, er):
+    def _er_to_rads(self, er):
         '''compute meters from electric revs'''
         rotations = er/(self.poll_pairs*self.gear_ratio)
-        distance = rotations*self.wheel_radius*2*math.pi
-        return distance
+        return rotations*2*math.pi
 
     def odometry_meters(self):
         return self._er_to_meters(self._latest_state.tachometer.value)
 
     def average_velocity(self):
-        return self._avg_velocity
+        return self._avg_velocity_rads*self.wheel_radius
+
+    def average_velocity_rads(self):
+        return self._avg_velocity_rads
 
     def send_rpm_command(self, rpm):
         RPM_FORMAT = '>i'  # big endian, int32
@@ -218,6 +220,10 @@ class HubMotor:
 
     def send_velocity_command(self, velocity_m_s):
         rpm = 60*velocity_m_s/(self.wheel_radius * 2*math.pi)
+        self.send_rpm_command(rpm)
+
+    def send_velocity_command_rads(self, rads_second):
+        rpm = 60*rads_second/(2*math.pi)
         self.send_rpm_command(rpm)
 
     def send_current_command(self, current_amps):

--- a/python/farm_ng/motor.py
+++ b/python/farm_ng/motor.py
@@ -7,6 +7,7 @@ import sys
 import linuxfd
 import numpy as np
 from farm_ng.canbus import CANSocket
+from farm_ng.config import default_config
 from farm_ng.ipc import get_event_bus
 from farm_ng.ipc import make_event
 from farm_ng_proto.tractor.v1 import motor_pb2
@@ -267,11 +268,19 @@ def main():
     print(f'Listening on can0')
     loop = asyncio.get_event_loop()
 
-    radius = (17.0*0.0254)/2.0  # in meters, 17" diameter wheels
-    gear_ratio = 29.9
-    poll_pairs = 8
-    right_motor = HubMotor('right_motor', radius, gear_ratio, poll_pairs, 7, can_socket)
-    left_motor = HubMotor('left_motor', radius, gear_ratio, poll_pairs, 9, can_socket)
+    config = default_config()
+    right_motor = HubMotor(
+        'right_motor',
+        config.wheel_radius.value,
+        config.hub_motor_gear_ratio.value,
+        config.hub_motor_poll_pairs.value, 7, can_socket,
+    )
+    left_motor = HubMotor(
+        'left_motor',
+        config.wheel_radius.value,
+        config.hub_motor_gear_ratio.value,
+        config.hub_motor_poll_pairs.value, 9, can_socket,
+    )
 
     count = [0]
 

--- a/python/farm_ng/pose_vis_toy.py
+++ b/python/farm_ng/pose_vis_toy.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 import numpy as np
+from farm_ng.config import default_config
 from farm_ng.ipc import get_event_bus
 from farm_ng.ipc import make_event
 from farm_ng.kinematics import TractorKinematics
@@ -25,7 +26,7 @@ class PoseVisToy:
         self.tractor_pose_wheel_left = SE3.exp((0.0, 1.0, 0, 0, 0, 0)).dot(SE3.exp((0.0, 0.0, 0, -np.pi/2, 0, 0)))
         self.tractor_pose_wheel_right = SE3.exp((0.0, -1.0, 0, 0, 0, 0)).dot(SE3.exp((0.0, 0.0, 0, -np.pi/2, 0, 0)))
 
-        self.kinematic_model = TractorKinematics()
+        self.kinematic_model = TractorKinematics(default_config())
 
         self.control_timer = Periodic(
             self.command_period_seconds, self.event_loop,
@@ -45,7 +46,7 @@ class PoseVisToy:
         self.event_bus.send(make_event('pose/tractor/base', pose_msg))
 
         pose_msg = NamedSE3Pose()
-        radius = 0.5*17*0.0254
+        radius = self.kinematic_model.wheel_radius
         self.tractor_pose_wheel_left = self.tractor_pose_wheel_left.dot(SE3.exp((0, 0, 0, 0, 0, left_speed/radius*self.command_period_seconds*n_periods)))
         pose_msg.a_pose_b.CopyFrom(se3_to_proto(self.tractor_pose_wheel_left))
         pose_msg.frame_a = 'tractor/base'

--- a/python/farm_ng/tractor.py
+++ b/python/farm_ng/tractor.py
@@ -3,13 +3,10 @@ import logging
 import sys
 
 import numpy as np
-from google.protobuf.text_format import MessageToString
-from google.protobuf.timestamp_pb2 import Timestamp
-from liegroups import SE3
-
 from farm_ng.canbus import CANSocket
 from farm_ng.config import default_config
-from farm_ng.ipc import get_event_bus, make_event
+from farm_ng.ipc import get_event_bus
+from farm_ng.ipc import make_event
 from farm_ng.kinematics import TractorKinematics
 from farm_ng.motor import HubMotor
 from farm_ng.periodic import Periodic
@@ -17,6 +14,9 @@ from farm_ng.proto_utils import se3_to_proto
 from farm_ng.steering import SteeringClient
 from farm_ng_proto.tractor.v1.geometry_pb2 import NamedSE3Pose
 from farm_ng_proto.tractor.v1.tractor_pb2 import TractorState
+from google.protobuf.text_format import MessageToString
+from google.protobuf.timestamp_pb2 import Timestamp
+from liegroups import SE3
 
 logger = logging.getLogger('tractor')
 logger.setLevel(logging.INFO)

--- a/python/farm_ng/tractor.py
+++ b/python/farm_ng/tractor.py
@@ -84,8 +84,8 @@ class TractorController:
             assert dt > 0.0
 
             tractor_pose_delta = self.kinematics.compute_tractor_pose_delta(
-                self._left_vel,
-                self._right_vel,
+                self.left_motor.average_velocity_rads(),
+                self.right_motor.average_velocity_rads(),
                 dt,
             )
             self.odom_pose_tractor = self.odom_pose_tractor.dot(tractor_pose_delta)

--- a/python/farm_ng/tractor.py
+++ b/python/farm_ng/tractor.py
@@ -3,10 +3,13 @@ import logging
 import sys
 
 import numpy as np
+from google.protobuf.text_format import MessageToString
+from google.protobuf.timestamp_pb2 import Timestamp
+from liegroups import SE3
+
 from farm_ng.canbus import CANSocket
 from farm_ng.config import default_config
-from farm_ng.ipc import get_event_bus
-from farm_ng.ipc import make_event
+from farm_ng.ipc import get_event_bus, make_event
 from farm_ng.kinematics import TractorKinematics
 from farm_ng.motor import HubMotor
 from farm_ng.periodic import Periodic
@@ -14,9 +17,6 @@ from farm_ng.proto_utils import se3_to_proto
 from farm_ng.steering import SteeringClient
 from farm_ng_proto.tractor.v1.geometry_pb2 import NamedSE3Pose
 from farm_ng_proto.tractor.v1.tractor_pb2 import TractorState
-from google.protobuf.text_format import MessageToString
-from google.protobuf.timestamp_pb2 import Timestamp
-from liegroups import SE3
 
 logger = logging.getLogger('tractor')
 logger.setLevel(logging.INFO)
@@ -113,8 +113,8 @@ class TractorController:
             self.angular = self.angular * (1-alpha) + steering_command.angular_velocity*alpha
 
             left, right = self.kinematics.unicycle_to_wheel_velocity(self.speed, self.angular)
-            self.right_motor.send_velocity_command(right)
-            self.left_motor.send_velocity_command(left)
+            self.right_motor.send_velocity_command_rads(right)
+            self.left_motor.send_velocity_command_rads(left)
 
 
 def main():

--- a/python/farm_ng/tractor.py
+++ b/python/farm_ng/tractor.py
@@ -4,6 +4,7 @@ import sys
 
 import numpy as np
 from farm_ng.canbus import CANSocket
+from farm_ng.config import default_config
 from farm_ng.ipc import get_event_bus
 from farm_ng.ipc import make_event
 from farm_ng.kinematics import TractorKinematics
@@ -19,8 +20,6 @@ from liegroups import SE3
 
 logger = logging.getLogger('tractor')
 logger.setLevel(logging.INFO)
-
-kinematics = TractorKinematics()
 
 
 class TractorController:
@@ -40,10 +39,13 @@ class TractorController:
         self.tractor_state = TractorState()
 
         self.odom_pose_tractor = SE3.identity()
+        # TODO(ethanrublee|isherman) load from disk somehow.
+        self.config = default_config()
 
-        radius = (17*0.0254)/2.0  # in meters, 15" diameter wheels
-        gear_ratio = 29.9
-        poll_pairs = 8
+        self.kinematics = TractorKinematics(tractor_config=self.config)
+        radius = self.config.wheel_radius.value
+        gear_ratio = self.config.hub_motor_gear_ratio.value
+        poll_pairs = self.config.hub_motor_poll_pairs.value
         self.right_motor = HubMotor(
             'right_motor',
             radius, gear_ratio, poll_pairs, 7, self.can_socket,
@@ -81,7 +83,7 @@ class TractorController:
             dt = (now.ToMicroseconds() - self._last_odom_stamp.ToMicroseconds())*1e-6
             assert dt > 0.0
 
-            tractor_pose_delta = kinematics.compute_tractor_pose_delta(
+            tractor_pose_delta = self.kinematics.compute_tractor_pose_delta(
                 self._left_vel,
                 self._right_vel,
                 dt,
@@ -110,7 +112,7 @@ class TractorController:
             self.speed = self.speed * (1-alpha) + steering_command.velocity*alpha
             self.angular = self.angular * (1-alpha) + steering_command.angular_velocity*alpha
 
-            left, right = kinematics.unicycle_to_wheel_velocity(self.speed, self.angular)
+            left, right = self.kinematics.unicycle_to_wheel_velocity(self.speed, self.angular)
             self.right_motor.send_velocity_command(right)
             self.left_motor.send_velocity_command(left)
 


### PR DESCRIPTION
Adds stub of tractor config, and a sample program to print json (but no persistence on disk).

Also, this fixes a units inconsistency between hub motor and the kinematic model, now that they both share the wheel_radius value.