### PR TITLE
Unify vscode / pre-commit python import formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,15 @@ repos:
     rev: v2.7.1
     hooks:
     -   id: validate_manifest
--   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.9.0
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.6.4
     hooks:
-    -   id: reorder-python-imports
-        args: [--py3-plus]
+    -   id: isort
+        name: sort python imports
+        args: [--force-single-line-imports,
+        --line-length=160,
+        --project=farm_ng,
+        --project=farm_ng_proto]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.0.1
     hooks:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
   "clang-format.style": "google",
-  "eslint.workingDirectories": [
-    "./app/frontend"
-  ],
+  "eslint.workingDirectories": ["./app/frontend"],
   "files.exclude": {
     "**/.git": true,
     "**/.DS_Store": true,
@@ -30,12 +28,16 @@
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": true,
   "python.linting.enabled": true,
+  "python.sortImports.args": [
+    "--force-single-line-imports",
+    "--line-length=160",
+    "--project=farm_ng",
+    "--project=farm_ng_proto"
+  ],
   "editor.formatOnSave": true,
   "protoc": {
     "compile_on_save": false,
-    "options": [
-      "--proto_path=${workspaceRoot}/protos"
-    ]
+    "options": ["--proto_path=${workspaceRoot}/protos"]
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/python/farm_ng/blobstore.py
+++ b/python/farm_ng/blobstore.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 
 import google.protobuf.json_format as json_format
+
 from farm_ng_proto.tractor.v1.resource_pb2 import Bucket
 
 logger = logging.getLogger('blobstore')

--- a/python/farm_ng/config.py
+++ b/python/farm_ng/config.py
@@ -1,12 +1,13 @@
 import argparse
 import os
 
+from google.protobuf.json_format import MessageToJson
+
 from farm_ng.blobstore import Blobstore
 from farm_ng_proto.tractor.v1.apriltag_pb2 import ApriltagConfig
 from farm_ng_proto.tractor.v1.apriltag_pb2 import TagConfig
 from farm_ng_proto.tractor.v1.resource_pb2 import BUCKET_CONFIGURATIONS
 from farm_ng_proto.tractor.v1.tractor_pb2 import TractorConfig
-from google.protobuf.json_format import MessageToJson
 
 
 def _in2m(inches: float) -> float:

--- a/python/farm_ng/ipc.py
+++ b/python/farm_ng/ipc.py
@@ -1,4 +1,3 @@
-# socket_multicast_receiver.py
 import asyncio
 import logging
 import re
@@ -12,15 +11,15 @@ from typing import Optional
 from typing import Pattern
 from typing import Set
 
+from google.protobuf.text_format import MessageToString
+from google.protobuf.timestamp_pb2 import Timestamp
+
+# loads all the protos for pretty print of any (isort:skip)
 import farm_ng.proto_utils  # noqa: F401
 from farm_ng.periodic import Periodic
 from farm_ng_proto.tractor.v1.io_pb2 import Announce
 from farm_ng_proto.tractor.v1.io_pb2 import Event
 from farm_ng_proto.tractor.v1.io_pb2 import Subscription
-from google.protobuf.text_format import MessageToString
-from google.protobuf.timestamp_pb2 import Timestamp
-
-# loads all the protos for pretty print of any
 
 logger = logging.getLogger('ipc')
 logger.setLevel(logging.INFO)

--- a/python/farm_ng/kinematics.py
+++ b/python/farm_ng/kinematics.py
@@ -1,7 +1,8 @@
 from typing import Tuple
 
-from farm_ng_proto.tractor.v1.tractor_pb2 import TractorConfig
 from liegroups import SE3
+
+from farm_ng_proto.tractor.v1.tractor_pb2 import TractorConfig
 
 
 class TractorKinematics:

--- a/python/farm_ng/metrics_demo.py
+++ b/python/farm_ng/metrics_demo.py
@@ -5,8 +5,8 @@ import time
 
 from prometheus_client import Counter
 from prometheus_client import Gauge
-from prometheus_client import start_http_server
 from prometheus_client import Summary
+from prometheus_client import start_http_server
 
 logging.basicConfig(stream=sys.stdout)
 logger = logging.getLogger('metrics_demo')

--- a/python/farm_ng/motor.py
+++ b/python/farm_ng/motor.py
@@ -6,13 +6,14 @@ import sys
 
 import linuxfd
 import numpy as np
+from google.protobuf.text_format import MessageToString
+from google.protobuf.timestamp_pb2 import Timestamp
+
 from farm_ng.canbus import CANSocket
 from farm_ng.config import TractorConfigManager
 from farm_ng.ipc import get_event_bus
 from farm_ng.ipc import make_event
 from farm_ng_proto.tractor.v1 import motor_pb2
-from google.protobuf.text_format import MessageToString
-from google.protobuf.timestamp_pb2 import Timestamp
 
 logger = logging.getLogger('farm_ng.motor')
 

--- a/python/farm_ng/proto_utils.py
+++ b/python/farm_ng/proto_utils.py
@@ -1,11 +1,12 @@
-# loads all the protos for the type registry
+import numpy as np
+from liegroups import SE3
+
+# loads all the protos for the type registry (isort:skip)
 import farm_ng_proto.tractor.v1.io_pb2  # noqa: F401
 import farm_ng_proto.tractor.v1.motor_pb2  # noqa: F401
 import farm_ng_proto.tractor.v1.steering_pb2  # noqa: F401
 import farm_ng_proto.tractor.v1.tracking_camera_pb2  # noqa: F401
-import numpy as np
 from farm_ng_proto.tractor.v1 import geometry_pb2
-from liegroups import SE3
 
 
 def se3_to_proto(pose: SE3) -> geometry_pb2.SE3Pose:

--- a/python/farm_ng/steering.py
+++ b/python/farm_ng/steering.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 import numpy as np
+
 from farm_ng.ipc import EventBus
 from farm_ng.ipc import get_event_bus
 from farm_ng.ipc import make_event

--- a/python/farm_ng/tractor.py
+++ b/python/farm_ng/tractor.py
@@ -4,6 +4,10 @@ import sys
 from collections import deque
 
 import numpy as np
+from google.protobuf.text_format import MessageToString
+from google.protobuf.timestamp_pb2 import Timestamp
+from liegroups import SE3
+
 from farm_ng.canbus import CANSocket
 from farm_ng.config import TractorConfigManager
 from farm_ng.controller import TractorMoveToGoalController
@@ -20,9 +24,6 @@ from farm_ng_proto.tractor.v1.geometry_pb2 import NamedSE3Pose
 from farm_ng_proto.tractor.v1.steering_pb2 import SteeringCommand
 from farm_ng_proto.tractor.v1.tractor_pb2 import TractorConfig
 from farm_ng_proto.tractor.v1.tractor_pb2 import TractorState
-from google.protobuf.text_format import MessageToString
-from google.protobuf.timestamp_pb2 import Timestamp
-from liegroups import SE3
 
 logger = logging.getLogger('tractor')
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
I was getting conflicts between my VSCode and pre-commit because they relied on two different import ordering tools. Should be unified now.