### PR TITLE
Fixes make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ build/
 
 # virtual env
 env/
+
+# yarn
+app/frontend/.cache

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ cpp:
 	cd build && rm -rf ./* && cmake -DCMAKE_PREFIX_PATH=`pwd`/../env -DCMAKE_BUILD_TYPE=Release .. && make -j`nproc --ignore=1`
 
 frontend:
-	cd app/frontend && yarn && yarn build
-	cp -rT app/frontend/dist build/frontend
+	scripts/build-frontend.sh
 
 protos:
 	scripts/build-protos.sh

--- a/scripts/Dockerfile.protoc
+++ b/scripts/Dockerfile.protoc
@@ -2,6 +2,8 @@ FROM golang:alpine
 # redo
 # Install protoc
 RUN apk add --update-cache \
+  bash \
+  findutils \
   git \
   nodejs-current-npm \
   protobuf \

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CMD="bash"
+CMD_ARGS="scripts/scripts_in_docker/build-frontend.sh"
+TAG="node"
+
+docker run \
+       --rm -v $PWD:/src:rw,Z -u $(id -u):$(id -g) --workdir /src \
+       --entrypoint $CMD $TAG $CMD_ARGS

--- a/scripts/build-protos.sh
+++ b/scripts/build-protos.sh
@@ -2,15 +2,8 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-CMD="protoc"
-CMD_ARGS="--proto_path=protos
-          --python_out=python/genproto
-          --go_out=module=github.com/farm_ng/genproto:go/genproto
-          --twirp_out=paths=source_relative:go/genproto
-          --ts_proto_out=app/frontend/genproto
-          --ts_proto_opt=forceLong=long
-          --twirp_tornado_srv_out=python/gensrv
-          protos/farm_ng_proto/tractor/v1/*.proto"
+CMD="bash"
+CMD_ARGS="scripts/scripts_in_docker/build-protos.sh"
 
 TAG="protoc"
 
@@ -18,9 +11,3 @@ docker build -t $TAG -f $DIR/Dockerfile.protoc $DIR
 docker run \
        --rm -v $PWD:/src:rw,Z -u $(id -u):$(id -g) --workdir /src \
        --entrypoint $CMD $TAG $CMD_ARGS
-
-# Twirp doesn't yet provide the 'module' flag to output generated code in a structure compatible
-# with Go Modules (https://github.com/twitchtv/twirp/issues/226), so clean it up manually.
-shopt -s globstar
-mv go/genproto/farm_ng_proto/**/*.twirp.go go/genproto
-find go/genproto -type d -empty -delete

--- a/scripts/scripts_in_docker/REAMDE.md
+++ b/scripts/scripts_in_docker/REAMDE.md
@@ -1,0 +1,1 @@
+These scripts are run inside docker containers.

--- a/scripts/scripts_in_docker/build-frontend.sh
+++ b/scripts/scripts_in_docker/build-frontend.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+mkdir -p /src/app/frontend/.cache/yarn
+export YARN_CACHE_FOLDER=/src/app/frontend/.cache/yarn
+
+cd app/frontend && yarn && yarn build && cd -
+cp -rT app/frontend/dist build/frontend

--- a/scripts/scripts_in_docker/build-protos.sh
+++ b/scripts/scripts_in_docker/build-protos.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+protoc \
+  --proto_path=protos \
+  --python_out=python/genproto \
+  --go_out=module=github.com/farm_ng/genproto:go/genproto \
+  --twirp_out=paths=source_relative:go/genproto \
+  --ts_proto_out=app/frontend/genproto \
+  --ts_proto_opt=forceLong=long \
+  --twirp_tornado_srv_out=python/gensrv \
+  protos/farm_ng_proto/tractor/v1/*.proto
+
+# Twirp doesn't yet provide the 'module' flag to output generated code in a structure compatible
+# with Go Modules (https://github.com/twitchtv/twirp/issues/226), so clean it up manually.
+shopt -s globstar
+mv go/genproto/farm_ng_proto/**/*.twirp.go go/genproto
+find go/genproto -type d -empty -delete


### PR DESCRIPTION
Move the building of protos and frontend applications inside a docker. Two advantages:
- No need to install yarn and nodejs in dev box or nano
- Remove potential bash version requirements for these two make commands

-------------
I encountered these two bash issues in my macos build.

1. Re: `make protos`
```
# This setting causes an error on older version of bash
shopt -s globstar
```

2. Re `make frontend`
```
$ echo $BASH_VERSION
5.0.18(1)-release

$ cp -rT app/frontend/dist build/frontend
cp: illegal option -- T
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
```