### PR TITLE
build and install issues on nano

### DIFF
--- a/bootstrap-apt.sh
+++ b/bootstrap-apt.sh
@@ -95,16 +95,16 @@ if ! prometheus --version | grep 2.21.0; then
   sudo cp /tmp/prometheus-2.21.0.linux-${arch}/prometheus /usr/local/bin
 fi
 
-
-# tractor-logs
-if [ ! -d "$HOME/tractor-logs" ]; then
-  if git clone git@github.com:farm-ng/tractor-logs.git $HOME/tractor-logs; then
-    cd ~/tractor-logs
-    git lfs install --local
-    git config user.email `hostname`
-    git config user.name `hostname`
-  else
-    echo "Please generate an SSH keypair and add it to the tractor-logs repository."
-    exit 1
-  fi
-fi
+# TODO: @jin this requires special permission
+# # tractor-logs
+# if [ ! -d "$HOME/tractor-logs" ]; then
+#   if git clone git@github.com:farm-ng/tractor-logs.git $HOME/tractor-logs; then
+#     cd ~/tractor-logs
+#     git lfs install --local
+#     git config user.email `hostname`
+#     git config user.name `hostname`
+#   else
+#     echo "Please generate an SSH keypair and add it to the tractor-logs repository."
+#     exit 1
+#   fi
+# fi


### PR DESCRIPTION
### make bootstrap issues
```
+ git clone git@github.com:farm-ng/tractor-logs.git /root/tractor-logs
Cloning into '/root/tractor-logs'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
+ echo 'Please generate an SSH keypair and add it to the tractor-logs repository.'
Please generate an SSH keypair and add it to the tractor-logs repository.
+ exit 1
```

### make third_party
- need install git module
- python issues with env setup
```
# even though protobuf is supposed to be installed by way of requirements; this has to be manually installed once to work
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/root/tractor/python/farm_ng/config.py", line 4, in <module>
    from google.protobuf.json_format import MessageToJson
ModuleNotFoundError: No module named 'google'
```

### make proto and make webserver
- go protos are not generate properly when they are generated
```
../genproto/webrtc_proxy_service.pb.go:28:6: InitiatePeerConnectionRequest redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.pb.go:103:6
../genproto/webrtc_proxy_service.pb.go:77:6: InitiatePeerConnectionResponse redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.pb.go:150:6
../genproto/webrtc_proxy_service.twirp.go:423:6: HTTPClient redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:734:6
../genproto/webrtc_proxy_service.twirp.go:431:6: TwirpServer redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:742:6
../genproto/webrtc_proxy_service.twirp.go:458:6: WriteError redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:765:47
../genproto/webrtc_proxy_service.twirp.go:463:6: writeError redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:770:82
../genproto/webrtc_proxy_service.twirp.go:545:6: getCustomHTTPReqHeaders redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:827:51
../genproto/webrtc_proxy_service.twirp.go:563:6: newRequest redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:845:105
../genproto/webrtc_proxy_service.twirp.go:579:6: twerrJSON redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:861:6
../genproto/webrtc_proxy_service.twirp.go:587:6: marshalErrorToJSON redeclared in this block
        previous declaration at ../genproto/webrtc_api_service.twirp.go:869:46
../genproto/webrtc_proxy_service.twirp.go:587:6: too many errors
```
