### PR TITLE
Rename ProgramOutput messages to avoid self subscription feedback.

### DIFF
--- a/modules/core/python/farm_ng/core/programd.py
+++ b/modules/core/python/farm_ng/core/programd.py
@@ -106,7 +106,7 @@ class ProgramSupervisor:
             out_buffer.write(line)
             out_buffer.flush()
             event = make_event(
-                f'{self.status.running.program.id}/{out_name}',
+                f'programd/{out_name}',
                 ProgramOutput(line=str(line, sys.stdout.encoding)),
             )
             self._event_bus.send(event)

--- a/modules/frontend/frontend/src/stores/ProgramsStore.ts
+++ b/modules/frontend/frontend/src/stores/ProgramsStore.ts
@@ -86,7 +86,7 @@ export class ProgramsStore {
         return;
       }
 
-      if (busEvent.name.startsWith(`${this.program?.programId}/`)) {
+      if (busEvent.name.startsWith("programd/stdout") || busEvent.name.startsWith("programd/stderr")) {
         if (
           (busEvent.data.typeUrl as EventTypeId) ==
           "type.googleapis.com/farm_ng.core.ProgramOutput"
@@ -99,6 +99,8 @@ export class ProgramsStore {
           this.outputLog.push(decoded.line);
           return;
         }
+      }
+      if (busEvent.name.startsWith(`${this.program?.programId}/`)) {
         this.statusLog.push([
           busEvent.stamp?.getTime() || Date.now(),
           busEvent,


### PR DESCRIPTION
Would be nice to add auto scroll somehow to follow the output.